### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.netconfig
+++ b/.netconfig
@@ -120,8 +120,8 @@
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = 55c0b32601e94e1eed35028a0cad510c6bcbb265
-	etag = 874f20853c983e6440ed67bb571d94927f9fb4cd4438585b07df7b420c664609
+	sha = fde1f6f17926f429a52e64de5ec355bb643e25bc
+	etag = 126357bbdcfd2ee087986bd27f1817926f6585fba7eda4c9acb36975474fd1b7
 	weak
 [file "support.md"]
 	url = https://github.com/devlooped/oss/blob/main/support.md

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,6 +5,10 @@
     <DefineConstants>CI;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   
+  <PropertyGroup Condition="'$(IsPackable)' == '' and '$(PackAsTool)' == 'true'">
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+  
   <PropertyGroup Condition="'$(IsPackable)' == ''">
     <!-- The Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets unconditionally sets 
         PackageId=AssemblyName if no PackageId is provided, and then defaults IsPackable=true if 


### PR DESCRIPTION
# devlooped/oss

- If PackAsTool=true, default IsPackable=true, for obvious reasons https://github.com/devlooped/oss/commit/fde1f6f